### PR TITLE
feat: Implement Telemetry MCP - Logging SIA Events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.pyc
 *-310.pyc
 *.md
+telemetry_logs/
+logs/

--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,11 @@ class Settings(BaseSettings):
     SERVE_THANKYOU_VIDEO_PATH: str = "./media/thankyou.mp4"
     WA_MEDIA_CACHE_PATH: str = "./media_cache.json"
     
+    # Logging configuration
+    LOG_FILE_PATH: str = ""
+    LOG_MAX_BYTES: int = 10_000_000  # 10 MB
+    LOG_BACKUP_COUNT: int = 3
+
     # Firebase configuration
     FIREBASE_SERVICE_ACCOUNT_JSON: str = "./serve-sandbox-firebase-adminsdk-4i44o-ac8df1245e.json"
     FIREBASE_PROJECT_ID: Optional[str] = None

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -601,14 +601,44 @@ TOOL_REGISTRY = {
     "telemetry.emit": {
         "endpoint": "/mcp/telemetry.emit",
         "method": "POST",
-        "description": "Emit telemetry event",
+        "description": "Log a telemetry event for analytics (drop-offs, failures, completions, state transitions). Events are persisted to JSONL files.",
         "inputSchema": {
             "type": "object",
             "properties": {
-                "event": {"type": "string"},
-                "payload": {"type": "object"}
+                "event": {"type": "string", "description": "Event type (e.g., 'onboarding.completed', 'tool.failed')"},
+                "payload": {"type": "object", "description": "Event payload data"},
+                "volunteerId": {"type": "string", "description": "Volunteer ID if applicable"},
+                "sessionId": {"type": "string", "description": "Session/conversation ID"},
+                "timestamp": {"type": "string", "description": "ISO8601 timestamp (auto-generated if not provided)"}
             },
-            "required": ["event", "payload"]
+            "required": ["event"]
+        }
+    },
+    "telemetry.query": {
+        "endpoint": "/mcp/telemetry.query",
+        "method": "POST",
+        "description": "Query telemetry events with filtering by volunteerId, eventType, or time range",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "volunteerId": {"type": "string", "description": "Filter by volunteer ID"},
+                "eventType": {"type": "string", "description": "Filter by event type (prefix match supported, e.g., 'onboarding' matches all onboarding events)"},
+                "since": {"type": "string", "description": "ISO8601 timestamp — only events after this time"},
+                "until": {"type": "string", "description": "ISO8601 timestamp — only events before this time"},
+                "limit": {"type": "integer", "default": 50, "minimum": 1, "maximum": 200, "description": "Max events to return"}
+            }
+        }
+    },
+    "telemetry.stats": {
+        "endpoint": "/mcp/telemetry.stats",
+        "method": "POST",
+        "description": "Get aggregate telemetry statistics: event counts by type, unique volunteers, time range",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "volunteerId": {"type": "string", "description": "Filter stats by volunteer ID"},
+                "since": {"type": "string", "description": "ISO8601 timestamp — stats after this time"}
+            }
         }
     },
     "onboarding.next": {

--- a/src/tools/telemetry.py
+++ b/src/tools/telemetry.py
@@ -1,16 +1,307 @@
-from fastapi import APIRouter
-from pydantic import BaseModel
-from typing import Dict
+"""
+Telemetry MCP Tool — Logging SIA Events
+- Log agent events (drop-offs, failures, completions, state transitions)
+- Persist events to JSONL file for analytics
+- Query events by volunteerId, eventType, or time range
+"""
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from typing import Dict, List, Optional, Any
+from datetime import datetime, timedelta, timezone
+import json
+import os
+import threading
 
 router = APIRouter()
 
+# --------- Configuration ---------
+
+TELEMETRY_LOG_DIR = os.environ.get("TELEMETRY_LOG_DIR", "./telemetry_logs")
+TELEMETRY_MAX_MEMORY_EVENTS = int(os.environ.get("TELEMETRY_MAX_MEMORY_EVENTS", "1000"))
+
+# --------- Event Schema ---------
+
+VALID_EVENT_TYPES = {
+    "onboarding.started",
+    "onboarding.step_completed",
+    "onboarding.completed",
+    "onboarding.dropped_off",
+    "onboarding.deferred",
+    "onboarding.rejected",
+    "eligibility.passed",
+    "eligibility.failed",
+    "scheduling.slot_proposed",
+    "scheduling.slot_confirmed",
+    "scheduling.slot_declined",
+    "volunteer.registered",
+    "volunteer.nominated",
+    "volunteer.status_updated",
+    "tool.called",
+    "tool.failed",
+    "tool.timeout",
+    "message.sent",
+    "message.received",
+    "error.unhandled",
+    "state.advanced",
+    "faq.answered",
+    "video.sent",
+}
+
+# --------- Models ---------
+
+
 class TelemetryEvent(BaseModel):
-    event: str
-    payload: Dict
+    event: str = Field(..., description="Event type (e.g., 'onboarding.completed')")
+    payload: Dict[str, Any] = Field(default_factory=dict, description="Event payload data")
+    volunteerId: Optional[str] = Field(None, description="Volunteer ID if applicable")
+    sessionId: Optional[str] = Field(None, description="Session/conversation ID")
+    timestamp: Optional[str] = Field(None, description="ISO8601 timestamp (auto-generated if not provided)")
 
-class OkResponse(BaseModel):
+
+class TelemetryEmitResponse(BaseModel):
     ok: bool
+    eventId: str
+    timestamp: str
+    event: str
 
-@router.post("/telemetry.emit", response_model=OkResponse)
-async def telemetry_emit(req: TelemetryEvent) -> OkResponse:
-    return OkResponse(ok=True)
+
+class TelemetryQueryRequest(BaseModel):
+    volunteerId: Optional[str] = Field(None, description="Filter by volunteer ID")
+    eventType: Optional[str] = Field(None, description="Filter by event type (prefix match supported)")
+    since: Optional[str] = Field(None, description="ISO8601 timestamp — only events after this time")
+    until: Optional[str] = Field(None, description="ISO8601 timestamp — only events before this time")
+    limit: int = Field(default=50, ge=1, le=200, description="Max events to return")
+
+
+class TelemetryQueryResponse(BaseModel):
+    events: List[Dict[str, Any]]
+    total: int
+    truncated: bool
+
+
+class TelemetryStatsRequest(BaseModel):
+    volunteerId: Optional[str] = Field(None, description="Filter stats by volunteer ID")
+    since: Optional[str] = Field(None, description="ISO8601 timestamp — stats after this time")
+
+
+class TelemetryStatsResponse(BaseModel):
+    total_events: int
+    by_type: Dict[str, int]
+    unique_volunteers: int
+    time_range: Dict[str, Optional[str]]
+
+
+# --------- In-Memory Store + File Persistence ---------
+
+_events: List[Dict[str, Any]] = []
+_lock = threading.Lock()
+_event_counter = 0
+
+
+def _ensure_log_dir():
+    """Create telemetry log directory if it doesn't exist."""
+    os.makedirs(TELEMETRY_LOG_DIR, exist_ok=True)
+
+
+def _get_log_file_path() -> str:
+    """Get current log file path (one file per day)."""
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return os.path.join(TELEMETRY_LOG_DIR, f"events_{today}.jsonl")
+
+
+def _persist_event(event_record: Dict[str, Any]):
+    """Append event to JSONL log file."""
+    try:
+        _ensure_log_dir()
+        log_path = _get_log_file_path()
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(event_record, ensure_ascii=False) + "\n")
+    except Exception as e:
+        print(f"[telemetry] Warning: Failed to persist event: {e}")
+
+
+def _generate_event_id() -> str:
+    """Generate a unique event ID."""
+    global _event_counter
+    _event_counter += 1
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    return f"evt_{ts}_{_event_counter:06d}"
+
+
+def _load_events_from_disk(since: Optional[datetime] = None) -> List[Dict[str, Any]]:
+    """Load events from JSONL files on disk (for queries spanning beyond memory)."""
+    events = []
+    try:
+        _ensure_log_dir()
+        files = sorted(os.listdir(TELEMETRY_LOG_DIR))
+        for fname in files:
+            if not fname.startswith("events_") or not fname.endswith(".jsonl"):
+                continue
+            fpath = os.path.join(TELEMETRY_LOG_DIR, fname)
+            with open(fpath, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                        if since:
+                            evt_time = datetime.fromisoformat(record.get("timestamp", "").replace("Z", "+00:00").replace("+00:00", ""))
+                            if evt_time < since:
+                                continue
+                        events.append(record)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+    except Exception as e:
+        print(f"[telemetry] Warning: Failed to load events from disk: {e}")
+    return events
+
+
+# --------- Endpoints ---------
+
+
+@router.post("/telemetry.emit", response_model=TelemetryEmitResponse)
+async def telemetry_emit(req: TelemetryEvent) -> TelemetryEmitResponse:
+    """
+    Log a telemetry event.
+
+    Accepts any event type (known types are validated but unknown types are still logged
+    with a warning flag). Events are stored in memory and persisted to JSONL files.
+    """
+    now = datetime.now(timezone.utc)
+    timestamp = req.timestamp or (now.isoformat() + "Z")
+    event_id = _generate_event_id()
+
+    event_record = {
+        "eventId": event_id,
+        "event": req.event,
+        "timestamp": timestamp,
+        "payload": req.payload,
+        "volunteerId": req.volunteerId,
+        "sessionId": req.sessionId,
+    }
+
+    if req.event not in VALID_EVENT_TYPES:
+        event_record["_warning"] = f"Unknown event type: {req.event}"
+
+    with _lock:
+        _events.append(event_record)
+        if len(_events) > TELEMETRY_MAX_MEMORY_EVENTS:
+            _events.pop(0)
+
+    _persist_event(event_record)
+
+    print(f"[telemetry] {req.event} | vol={req.volunteerId or '-'} | session={req.sessionId or '-'}")
+
+    return TelemetryEmitResponse(
+        ok=True,
+        eventId=event_id,
+        timestamp=timestamp,
+        event=req.event,
+    )
+
+
+@router.post("/telemetry.query", response_model=TelemetryQueryResponse)
+async def telemetry_query(req: TelemetryQueryRequest) -> TelemetryQueryResponse:
+    """
+    Query telemetry events with filtering.
+
+    Searches in-memory events first, falls back to disk if needed.
+    """
+    with _lock:
+        source_events = list(_events)
+
+    if req.since:
+        try:
+            since_dt = datetime.fromisoformat(req.since.replace("Z", ""))
+            disk_events = _load_events_from_disk(since=since_dt)
+            seen_ids = {e["eventId"] for e in source_events}
+            for de in disk_events:
+                if de.get("eventId") not in seen_ids:
+                    source_events.append(de)
+        except ValueError:
+            pass
+
+    filtered = []
+    for evt in source_events:
+        if req.volunteerId and evt.get("volunteerId") != req.volunteerId:
+            continue
+        if req.eventType:
+            if not evt.get("event", "").startswith(req.eventType):
+                continue
+        if req.since:
+            evt_ts = evt.get("timestamp", "")
+            if evt_ts < req.since:
+                continue
+        if req.until:
+            evt_ts = evt.get("timestamp", "")
+            if evt_ts > req.until:
+                continue
+        filtered.append(evt)
+
+    filtered.sort(key=lambda e: e.get("timestamp", ""), reverse=True)
+
+    total = len(filtered)
+    truncated = total > req.limit
+    results = filtered[: req.limit]
+
+    return TelemetryQueryResponse(
+        events=results,
+        total=total,
+        truncated=truncated,
+    )
+
+
+@router.post("/telemetry.stats", response_model=TelemetryStatsResponse)
+async def telemetry_stats(req: TelemetryStatsRequest) -> TelemetryStatsResponse:
+    """
+    Get aggregate telemetry statistics.
+
+    Returns event counts by type, unique volunteers, and time range.
+    """
+    with _lock:
+        source_events = list(_events)
+
+    if req.since:
+        try:
+            since_dt = datetime.fromisoformat(req.since.replace("Z", ""))
+            disk_events = _load_events_from_disk(since=since_dt)
+            seen_ids = {e["eventId"] for e in source_events}
+            for de in disk_events:
+                if de.get("eventId") not in seen_ids:
+                    source_events.append(de)
+        except ValueError:
+            pass
+
+    filtered = source_events
+    if req.volunteerId:
+        filtered = [e for e in filtered if e.get("volunteerId") == req.volunteerId]
+    if req.since:
+        filtered = [e for e in filtered if e.get("timestamp", "") >= req.since]
+
+    by_type: Dict[str, int] = {}
+    volunteers = set()
+    timestamps = []
+
+    for evt in filtered:
+        etype = evt.get("event", "unknown")
+        by_type[etype] = by_type.get(etype, 0) + 1
+        vid = evt.get("volunteerId")
+        if vid:
+            volunteers.add(vid)
+        ts = evt.get("timestamp")
+        if ts:
+            timestamps.append(ts)
+
+    time_range: Dict[str, Optional[str]] = {"earliest": None, "latest": None}
+    if timestamps:
+        timestamps.sort()
+        time_range["earliest"] = timestamps[0]
+        time_range["latest"] = timestamps[-1]
+
+    return TelemetryStatsResponse(
+        total_events=len(filtered),
+        by_type=by_type,
+        unique_volunteers=len(volunteers),
+        time_range=time_range,
+    )

--- a/test_telemetry.py
+++ b/test_telemetry.py
@@ -1,0 +1,186 @@
+"""
+Unit tests for Telemetry MCP tool.
+Tests the telemetry router independently without needing the full app.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+os.environ["TELEMETRY_LOG_DIR"] = "/tmp/telemetry_test_logs"
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+
+@pytest.fixture
+def app():
+    """Create a minimal FastAPI app with just the telemetry router."""
+    from tools.telemetry import router, _events, _lock
+    with _lock:
+        _events.clear()
+    test_app = FastAPI()
+    test_app.include_router(router, prefix="/mcp")
+    return test_app
+
+
+@pytest.fixture(autouse=True)
+def clear_events():
+    """Clear in-memory events before each test."""
+    from tools.telemetry import _events, _lock
+    with _lock:
+        _events.clear()
+    yield
+    with _lock:
+        _events.clear()
+
+
+@pytest.mark.asyncio
+async def test_emit_basic(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/telemetry.emit", json={
+            "event": "onboarding.completed",
+            "payload": {"step": "done"},
+            "volunteerId": "vol-123"
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["event"] == "onboarding.completed"
+        assert data["eventId"].startswith("evt_")
+        assert data["timestamp"].endswith("Z")
+
+
+@pytest.mark.asyncio
+async def test_emit_unknown_event_type(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/telemetry.emit", json={
+            "event": "custom.unknown_event",
+            "payload": {"info": "test"}
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_emit_minimal_payload(app):
+    """Event with only required field (event type)."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/telemetry.emit", json={
+            "event": "tool.called",
+            "payload": {}
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_query_by_volunteer(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/mcp/telemetry.emit", json={
+            "event": "onboarding.started", "payload": {}, "volunteerId": "vol-A"
+        })
+        await client.post("/mcp/telemetry.emit", json={
+            "event": "onboarding.started", "payload": {}, "volunteerId": "vol-B"
+        })
+        await client.post("/mcp/telemetry.emit", json={
+            "event": "onboarding.completed", "payload": {}, "volunteerId": "vol-A"
+        })
+
+        resp = await client.post("/mcp/telemetry.query", json={
+            "volunteerId": "vol-A"
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        assert all(e["volunteerId"] == "vol-A" for e in data["events"])
+
+
+@pytest.mark.asyncio
+async def test_query_by_event_type_prefix(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/mcp/telemetry.emit", json={
+            "event": "onboarding.started", "payload": {}
+        })
+        await client.post("/mcp/telemetry.emit", json={
+            "event": "onboarding.completed", "payload": {}
+        })
+        await client.post("/mcp/telemetry.emit", json={
+            "event": "tool.called", "payload": {}
+        })
+
+        resp = await client.post("/mcp/telemetry.query", json={
+            "eventType": "onboarding"
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_query_limit(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        for i in range(10):
+            await client.post("/mcp/telemetry.emit", json={
+                "event": "tool.called", "payload": {"i": i}
+            })
+
+        resp = await client.post("/mcp/telemetry.query", json={
+            "limit": 3
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["events"]) == 3
+        assert data["total"] == 10
+        assert data["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_stats(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/mcp/telemetry.emit", json={
+            "event": "onboarding.started", "payload": {}, "volunteerId": "v1"
+        })
+        await client.post("/mcp/telemetry.emit", json={
+            "event": "onboarding.started", "payload": {}, "volunteerId": "v2"
+        })
+        await client.post("/mcp/telemetry.emit", json={
+            "event": "tool.called", "payload": {}, "volunteerId": "v1"
+        })
+
+        resp = await client.post("/mcp/telemetry.stats", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_events"] == 3
+        assert data["by_type"]["onboarding.started"] == 2
+        assert data["by_type"]["tool.called"] == 1
+        assert data["unique_volunteers"] == 2
+
+
+@pytest.mark.asyncio
+async def test_stats_filtered_by_volunteer(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/mcp/telemetry.emit", json={
+            "event": "onboarding.started", "payload": {}, "volunteerId": "v1"
+        })
+        await client.post("/mcp/telemetry.emit", json={
+            "event": "onboarding.completed", "payload": {}, "volunteerId": "v2"
+        })
+
+        resp = await client.post("/mcp/telemetry.stats", json={
+            "volunteerId": "v1"
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_events"] == 1
+        assert data["unique_volunteers"] == 1


### PR DESCRIPTION
## Summary
- Replaces the no-op `telemetry.emit` stub with a full implementation that logs events to JSONL files
- Adds `telemetry.query` endpoint for filtering events by volunteerId, eventType, or time range
- Adds `telemetry.stats` endpoint for aggregate statistics (counts by type, unique volunteers, time range)
- Registers new tools in MCP server's TOOL_REGISTRY
- Adds LOG_MAX_BYTES and LOG_BACKUP_COUNT settings to config
- Includes 8 unit tests covering emit, query, and stats functionality

Closes #6

## Test plan
- [x] `python3 -m pytest test_telemetry.py -v` — all 8 tests pass
- [ ] Manual verification: emit events and verify JSONL files are created in `telemetry_logs/`
- [ ] Verify MCP JSON-RPC interface exposes the new tools via `tools/list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)