### PR TITLE
feat: Persistent Conversation State Store with TTL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.pyc
 *-310.pyc
 *.md
+state_store/
+telemetry_logs/
+logs/

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -429,7 +429,7 @@ TOOL_REGISTRY = {
     "state.get": {
         "endpoint": "/mcp/state.get",
         "method": "POST",
-        "description": "Get the current onboarding state for a volunteer (returns WELCOME if new)",
+        "description": "Get the current onboarding state for a volunteer (returns WELCOME if new). Includes TTL expiry check.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -441,7 +441,7 @@ TOOL_REGISTRY = {
     "state.advance": {
         "endpoint": "/mcp/state.advance",
         "method": "POST",
-        "description": "Advance volunteer's onboarding state based on intent (with validation)",
+        "description": "Advance volunteer's onboarding state based on intent (with validation). Persisted to disk.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -450,6 +450,32 @@ TOOL_REGISTRY = {
                 "idempotency_key": {"type": "string", "description": "Optional key to prevent duplicate transitions"}
             },
             "required": ["volunteerId", "intent"]
+        }
+    },
+    "conversation.save": {
+        "endpoint": "/mcp/conversation.save",
+        "method": "POST",
+        "description": "Save full conversation state (arbitrary JSON) for a volunteer so agents can resume flows. Supports configurable TTL.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "volunteerId": {"type": "string", "description": "Volunteer ID"},
+                "state": {"type": "object", "description": "Full conversation state object to persist"},
+                "ttl_hours": {"type": "integer", "minimum": 1, "maximum": 720, "description": "Custom TTL in hours (default: 72)"}
+            },
+            "required": ["volunteerId", "state"]
+        }
+    },
+    "conversation.get": {
+        "endpoint": "/mcp/conversation.get",
+        "method": "POST",
+        "description": "Retrieve conversation state for a volunteer. Returns state with expiry info.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "volunteerId": {"type": "string", "description": "Volunteer ID"}
+            },
+            "required": ["volunteerId"]
         }
     },
     "eligibility.check": {

--- a/src/tools/state.py
+++ b/src/tools/state.py
@@ -1,29 +1,34 @@
 """
-State Management Tool
-- Get current onboarding state for a volunteer
-- Advance state based on intent (with validation)
-- Supports idempotency for state transitions
+State MCP: Conversation State Store
+- Save and retrieve conversation state so agents can resume flows
+- File-based persistence (JSONL) for durability across restarts
+- Configurable TTL/expiry for stale states
+- Supports full conversation state (not just onboarding step)
 """
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 from typing import Dict, Optional, List, Any
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
+import json
+import os
 import uuid
+import threading
 
 router = APIRouter()
 
-# In-memory storage (temporary - will be replaced with database)
-_STATE_STORE: Dict[str, Dict] = {}  # Key: volunteerId
-_TRANSITION_STORE: Dict[str, Dict] = {}  # Key: idempotency_key
+# --------- Configuration ---------
 
-# State machine: valid transitions
+STATE_STORE_DIR = os.environ.get("STATE_STORE_DIR", "./state_store")
+STATE_TTL_HOURS = int(os.environ.get("STATE_TTL_HOURS", "72"))  # 3 days default
+
+# --------- State Machine (Onboarding) ---------
+
 VALID_STATES = {
     "WELCOME", "ELIGIBILITY_PART1", "ELIGIBILITY_PART2", "TIME_PREF",
     "SCHEDULING", "DONE", "REJECTED", "DEFERRED", "OPTOUT",
     "QA_WINDOW", "ORIENTATION_CONSENT", "ORIENTATION_SCHEDULING"
 }
 
-# Forward-only normal flow transitions
 FORWARD_TRANSITIONS = {
     "WELCOME": {"to_ELIGIBILITY_PART1"},
     "ELIGIBILITY_PART1": {"to_ELIGIBILITY_PART2"},
@@ -32,10 +37,8 @@ FORWARD_TRANSITIONS = {
     "SCHEDULING": {"to_DONE"}
 }
 
-# Terminal states (can be reached from any state)
 TERMINAL_STATES = {"REJECTED", "DEFERRED", "OPTOUT"}
 
-# Intent to state mapping
 INTENT_TO_STATE = {
     "to_ELIGIBILITY_PART1": "ELIGIBILITY_PART1",
     "to_ELIGIBILITY_PART2": "ELIGIBILITY_PART2",
@@ -50,7 +53,6 @@ INTENT_TO_STATE = {
     "to_ORIENTATION_SCHEDULING": "ORIENTATION_SCHEDULING"
 }
 
-# Required fields for each state (for next_required_fields in response)
 STATE_REQUIRED_FIELDS = {
     "ELIGIBILITY_PART1": ["age_ok", "has_device"],
     "ELIGIBILITY_PART2": ["weekly_commitment_hours"],
@@ -62,169 +64,273 @@ STATE_REQUIRED_FIELDS = {
     "DONE": []
 }
 
+# --------- Persistent Store ---------
+
+_STATE_STORE: Dict[str, Dict] = {}
+_TRANSITION_STORE: Dict[str, Dict] = {}
+_CONVERSATION_STORE: Dict[str, Dict] = {}
+_lock = threading.Lock()
+_loaded = False
+
+
+def _ensure_store_dir():
+    os.makedirs(STATE_STORE_DIR, exist_ok=True)
+
+
+def _state_file_path() -> str:
+    return os.path.join(STATE_STORE_DIR, "states.jsonl")
+
+
+def _conversation_file_path() -> str:
+    return os.path.join(STATE_STORE_DIR, "conversations.jsonl")
+
+
+def _load_from_disk():
+    """Load state from JSONL files on first access."""
+    global _loaded
+    if _loaded:
+        return
+    _loaded = True
+
+    _ensure_store_dir()
+
+    # Load onboarding states
+    state_path = _state_file_path()
+    if os.path.exists(state_path):
+        try:
+            with open(state_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                        vid = record.get("volunteerId")
+                        if vid:
+                            _STATE_STORE[vid] = record
+                    except json.JSONDecodeError:
+                        continue
+        except Exception as e:
+            print(f"[state] Warning: Failed to load states: {e}")
+
+    # Load conversation states
+    conv_path = _conversation_file_path()
+    if os.path.exists(conv_path):
+        try:
+            with open(conv_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                        vid = record.get("volunteerId")
+                        if vid:
+                            _CONVERSATION_STORE[vid] = record
+                    except json.JSONDecodeError:
+                        continue
+        except Exception as e:
+            print(f"[state] Warning: Failed to load conversations: {e}")
+
+
+def _persist_state(volunteer_id: str, record: Dict):
+    """Append state record to JSONL file."""
+    try:
+        _ensure_store_dir()
+        record["volunteerId"] = volunteer_id
+        with open(_state_file_path(), "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception as e:
+        print(f"[state] Warning: Failed to persist state: {e}")
+
+
+def _persist_conversation(volunteer_id: str, record: Dict):
+    """Append conversation state to JSONL file."""
+    try:
+        _ensure_store_dir()
+        record["volunteerId"] = volunteer_id
+        with open(_conversation_file_path(), "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception as e:
+        print(f"[state] Warning: Failed to persist conversation: {e}")
+
+
+def _is_expired(record: Dict) -> bool:
+    """Check if a state record has expired based on TTL."""
+    updated_at = record.get("updated_at")
+    if not updated_at:
+        return False
+    try:
+        ts = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+        expiry = ts + timedelta(hours=STATE_TTL_HOURS)
+        return datetime.now(timezone.utc) > expiry
+    except (ValueError, TypeError):
+        return False
+
+
+# --------- Models ---------
+
+
 class StateGetRequest(BaseModel):
     volunteerId: str = Field(..., description="Unique volunteer identifier")
+
 
 class StateMetadata(BaseModel):
     last_completed_step: Optional[str] = None
     progress_percentage: Optional[int] = Field(None, ge=0, le=100)
     flags: Optional[Dict[str, Any]] = None
 
+
 class StateGetResponse(BaseModel):
     state: str
-    updated_at: Optional[str] = None  # ISO8601 datetime or null
+    updated_at: Optional[str] = None
     metadata: Optional[StateMetadata] = None
+    expired: bool = False
+
 
 class StateAdvanceRequest(BaseModel):
     volunteerId: str = Field(..., description="Unique volunteer identifier")
     intent: str = Field(..., description="Intent to advance (e.g., 'to_ELIGIBILITY_PART1')")
-    idempotency_key: Optional[str] = Field(None, description="Optional idempotency key to prevent duplicate transitions")
+    idempotency_key: Optional[str] = Field(None, description="Optional idempotency key")
+
 
 class StateAdvanceResponse(BaseModel):
     new_state: str
     previous_state: str
-    transitioned_at: str  # ISO8601 datetime
+    transitioned_at: str
     next_required_fields: Optional[List[str]] = None
     metadata: Optional[Dict[str, Any]] = None
 
+
+class ConversationSaveRequest(BaseModel):
+    volunteerId: str = Field(..., description="Volunteer ID")
+    state: Dict[str, Any] = Field(..., description="Full conversation state object to persist")
+    ttl_hours: Optional[int] = Field(None, ge=1, le=720, description="Custom TTL in hours (default: 72)")
+
+
+class ConversationSaveResponse(BaseModel):
+    saved: bool
+    volunteerId: str
+    expires_at: str
+    version: int
+
+
+class ConversationGetRequest(BaseModel):
+    volunteerId: str = Field(..., description="Volunteer ID")
+
+
+class ConversationGetResponse(BaseModel):
+    found: bool
+    volunteerId: str
+    state: Optional[Dict[str, Any]] = None
+    updated_at: Optional[str] = None
+    expires_at: Optional[str] = None
+    expired: bool = False
+    version: int = 0
+
+
+# --------- Helper Functions ---------
+
+
 def _calculate_progress(state: str) -> int:
-    """Calculate progress percentage based on state"""
     progress_map = {
-        "WELCOME": 0,
-        "ELIGIBILITY_PART1": 25,
-        "ELIGIBILITY_PART2": 40,
-        "TIME_PREF": 60,
-        "SCHEDULING": 80,
-        "QA_WINDOW": 70,
-        "ORIENTATION_CONSENT": 75,
-        "ORIENTATION_SCHEDULING": 85,
-        "DONE": 100,
-        "REJECTED": 0,
-        "DEFERRED": 0,
-        "OPTOUT": 0
+        "WELCOME": 0, "ELIGIBILITY_PART1": 25, "ELIGIBILITY_PART2": 40,
+        "TIME_PREF": 60, "SCHEDULING": 80, "QA_WINDOW": 70,
+        "ORIENTATION_CONSENT": 75, "ORIENTATION_SCHEDULING": 85,
+        "DONE": 100, "REJECTED": 0, "DEFERRED": 0, "OPTOUT": 0
     }
     return progress_map.get(state, 0)
 
+
 def _get_last_completed_step(state: str) -> Optional[str]:
-    """Get last completed step based on current state"""
     step_map = {
-        "ELIGIBILITY_PART1": "WELCOME",
-        "ELIGIBILITY_PART2": "ELIGIBILITY_PART1",
-        "TIME_PREF": "ELIGIBILITY_PART2",
-        "SCHEDULING": "TIME_PREF",
-        "DONE": "SCHEDULING"
+        "ELIGIBILITY_PART1": "WELCOME", "ELIGIBILITY_PART2": "ELIGIBILITY_PART1",
+        "TIME_PREF": "ELIGIBILITY_PART2", "SCHEDULING": "TIME_PREF", "DONE": "SCHEDULING"
     }
     return step_map.get(state)
 
+
 def _validate_transition(current_state: str, intent: str, target_state: str) -> bool:
-    """Validate if transition from current_state to target_state is valid"""
-    # Terminal states can be reached from any state
     if target_state in TERMINAL_STATES:
         return True
-    
-    # Check forward transitions
     if current_state in FORWARD_TRANSITIONS:
-        allowed_intents = FORWARD_TRANSITIONS[current_state]
-        if intent in allowed_intents:
+        if intent in FORWARD_TRANSITIONS[current_state]:
             return True
-    
-    # Check if intent maps to target state correctly
-    if INTENT_TO_STATE.get(intent) == target_state:
-        # Additional validation: prevent backwards transitions
-        state_order = ["WELCOME", "ELIGIBILITY_PART1", "ELIGIBILITY_PART2", "TIME_PREF", "SCHEDULING", "DONE"]
-        try:
-            current_idx = state_order.index(current_state)
-            target_idx = state_order.index(target_state)
-            if target_idx > current_idx:  # Forward transition
-                return True
-            elif target_idx == current_idx:  # Same state (no-op, but allow)
-                return True
-            else:  # Backwards transition
-                return False
-        except ValueError:
-            # States not in order list (terminal states), allow if intent matches
-            return True
-    
+    # Allow same-state (idempotent)
+    if current_state == target_state:
+        return True
+    # Allow orientation states from any non-terminal state
+    if target_state in ("ORIENTATION_CONSENT", "ORIENTATION_SCHEDULING"):
+        return True
     return False
+
+
+# --------- Endpoints ---------
+
 
 @router.post("/state.get", response_model=StateGetResponse)
 async def get_state(req: StateGetRequest) -> StateGetResponse:
-    """
-    Get the current onboarding state for a volunteer.
-    
-    Returns default "WELCOME" state if volunteer has no state record.
-    """
+    """Get the current onboarding state for a volunteer."""
+    with _lock:
+        _load_from_disk()
+
     volunteer_id = req.volunteerId
-    
+
     if volunteer_id in _STATE_STORE:
         state_record = _STATE_STORE[volunteer_id]
         current_state = state_record.get("state", "WELCOME")
         updated_at = state_record.get("updated_at")
-        
+        expired = _is_expired(state_record)
+
         metadata = StateMetadata(
             last_completed_step=_get_last_completed_step(current_state),
             progress_percentage=_calculate_progress(current_state),
             flags=state_record.get("flags", {})
         )
-        
+
         return StateGetResponse(
             state=current_state,
             updated_at=updated_at,
-            metadata=metadata
+            metadata=metadata,
+            expired=expired,
         )
-    
-    # New volunteer - return default state
+
     return StateGetResponse(
         state="WELCOME",
         updated_at=None,
-        metadata=StateMetadata(
-            last_completed_step=None,
-            progress_percentage=0,
-            flags={}
-        )
+        metadata=StateMetadata(last_completed_step=None, progress_percentage=0, flags={}),
+        expired=False,
     )
+
 
 @router.post("/state.advance", response_model=StateAdvanceResponse)
 async def advance_state(req: StateAdvanceRequest) -> StateAdvanceResponse:
-    """
-    Advance a volunteer's onboarding state based on intent.
-    
-    Validates transition is allowed (prevents invalid backwards/invalid moves).
-    Supports idempotency to prevent duplicate transitions.
-    """
+    """Advance a volunteer's onboarding state based on intent."""
+    with _lock:
+        _load_from_disk()
+
     volunteer_id = req.volunteerId
     intent = req.intent
-    
-    # Validate intent exists
+
     if intent not in INTENT_TO_STATE:
         raise HTTPException(
             status_code=422,
             detail=f"Invalid intent: '{intent}'. Valid intents: {list(INTENT_TO_STATE.keys())}"
         )
-    
+
     target_state = INTENT_TO_STATE[intent]
-    
-    # Get current state
+
     current_state = "WELCOME"
     if volunteer_id in _STATE_STORE:
         current_state = _STATE_STORE[volunteer_id].get("state", "WELCOME")
-    
-    # Validate target state
+
     if target_state not in VALID_STATES:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Invalid target state: '{target_state}'. Valid states: {list(VALID_STATES)}"
-        )
-    
-    # Generate idempotency key if not provided
-    idempotency_key = req.idempotency_key
-    if not idempotency_key:
-        idempotency_key = f"{volunteer_id}_{intent}_{int(datetime.utcnow().timestamp())}"
-    
-    # Check for existing transition (idempotency)
+        raise HTTPException(status_code=422, detail=f"Invalid target state: '{target_state}'")
+
+    idempotency_key = req.idempotency_key or f"{volunteer_id}_{intent}_{int(datetime.now(timezone.utc).timestamp())}"
+
     if idempotency_key in _TRANSITION_STORE:
         existing = _TRANSITION_STORE[idempotency_key]
-        print(f"[state.advance] Found existing transition for idempotency_key: {idempotency_key}")
         return StateAdvanceResponse(
             new_state=existing["new_state"],
             previous_state=existing["previous_state"],
@@ -232,44 +338,42 @@ async def advance_state(req: StateAdvanceRequest) -> StateAdvanceResponse:
             next_required_fields=existing.get("next_required_fields"),
             metadata=existing.get("metadata", {})
         )
-    
-    # Validate transition
+
     if not _validate_transition(current_state, intent, target_state):
         raise HTTPException(
             status_code=422,
             detail=f"Invalid transition: cannot advance from '{current_state}' to '{target_state}' with intent '{intent}'"
         )
-    
-    # Perform transition
-    now_iso = datetime.utcnow().isoformat() + "Z"
+
+    now_iso = datetime.now(timezone.utc).isoformat()
     previous_state = current_state
-    
-    # Update state store
-    if volunteer_id not in _STATE_STORE:
-        _STATE_STORE[volunteer_id] = {}
-    
-    _STATE_STORE[volunteer_id]["state"] = target_state
-    _STATE_STORE[volunteer_id]["updated_at"] = now_iso
-    if "flags" not in _STATE_STORE[volunteer_id]:
-        _STATE_STORE[volunteer_id]["flags"] = {}
-    
-    # Store transition record
-    transition_id = f"trans_{uuid.uuid4().hex[:12]}"
-    transition_record = {
-        "new_state": target_state,
-        "previous_state": previous_state,
-        "transitioned_at": now_iso,
-        "next_required_fields": STATE_REQUIRED_FIELDS.get(target_state),
-        "metadata": {
-            "transition_id": transition_id,
-            "triggered_by": intent,
-            "volunteer_id": volunteer_id
+
+    with _lock:
+        if volunteer_id not in _STATE_STORE:
+            _STATE_STORE[volunteer_id] = {}
+        _STATE_STORE[volunteer_id]["state"] = target_state
+        _STATE_STORE[volunteer_id]["updated_at"] = now_iso
+        if "flags" not in _STATE_STORE[volunteer_id]:
+            _STATE_STORE[volunteer_id]["flags"] = {}
+
+        transition_id = f"trans_{uuid.uuid4().hex[:12]}"
+        transition_record = {
+            "new_state": target_state,
+            "previous_state": previous_state,
+            "transitioned_at": now_iso,
+            "next_required_fields": STATE_REQUIRED_FIELDS.get(target_state),
+            "metadata": {
+                "transition_id": transition_id,
+                "triggered_by": intent,
+                "volunteer_id": volunteer_id
+            }
         }
-    }
-    _TRANSITION_STORE[idempotency_key] = transition_record
-    
-    print(f"[state.advance] Transitioned {volunteer_id}: {previous_state} → {target_state} (intent: {intent})")
-    
+        _TRANSITION_STORE[idempotency_key] = transition_record
+
+    _persist_state(volunteer_id, _STATE_STORE[volunteer_id])
+
+    print(f"[state.advance] {volunteer_id}: {previous_state} -> {target_state} (intent: {intent})")
+
     return StateAdvanceResponse(
         new_state=target_state,
         previous_state=previous_state,
@@ -278,3 +382,81 @@ async def advance_state(req: StateAdvanceRequest) -> StateAdvanceResponse:
         metadata=transition_record["metadata"]
     )
 
+
+@router.post("/conversation.save", response_model=ConversationSaveResponse)
+async def conversation_save(req: ConversationSaveRequest) -> ConversationSaveResponse:
+    """
+    Save full conversation state for a volunteer.
+
+    This stores arbitrary JSON state (context, collected facts, partial responses, etc.)
+    so that agents can resume flows after disconnection or handoff.
+    """
+    with _lock:
+        _load_from_disk()
+
+    now = datetime.now(timezone.utc)
+    ttl = req.ttl_hours or STATE_TTL_HOURS
+    expires_at = now + timedelta(hours=ttl)
+
+    version = 1
+    if req.volunteerId in _CONVERSATION_STORE:
+        version = _CONVERSATION_STORE[req.volunteerId].get("version", 0) + 1
+
+    record = {
+        "state": req.state,
+        "updated_at": now.isoformat(),
+        "expires_at": expires_at.isoformat(),
+        "version": version,
+        "ttl_hours": ttl,
+    }
+
+    with _lock:
+        _CONVERSATION_STORE[req.volunteerId] = record
+
+    _persist_conversation(req.volunteerId, record)
+
+    return ConversationSaveResponse(
+        saved=True,
+        volunteerId=req.volunteerId,
+        expires_at=expires_at.isoformat(),
+        version=version,
+    )
+
+
+@router.post("/conversation.get", response_model=ConversationGetResponse)
+async def conversation_get(req: ConversationGetRequest) -> ConversationGetResponse:
+    """
+    Retrieve conversation state for a volunteer.
+
+    Returns the stored state along with expiry info. If expired, the state is still
+    returned (for debugging) but marked as expired.
+    """
+    with _lock:
+        _load_from_disk()
+
+    if req.volunteerId not in _CONVERSATION_STORE:
+        return ConversationGetResponse(
+            found=False,
+            volunteerId=req.volunteerId,
+        )
+
+    record = _CONVERSATION_STORE[req.volunteerId]
+    expires_at = record.get("expires_at")
+
+    expired = False
+    if expires_at:
+        try:
+            exp_dt = datetime.fromisoformat(expires_at)
+            expired = datetime.now(timezone.utc) > exp_dt
+        except (ValueError, TypeError):
+            pass
+
+    return ConversationGetResponse(
+        found=True,
+        volunteerId=req.volunteerId,
+        state=record.get("state"),
+        updated_at=record.get("updated_at"),
+        expires_at=expires_at,
+        expired=expired,
+        version=record.get("version", 0),
+    )

--- a/test_state.py
+++ b/test_state.py
@@ -1,0 +1,153 @@
+"""
+Unit tests for State MCP: Conversation State Store.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+os.environ["STATE_STORE_DIR"] = "/tmp/state_store_test"
+os.environ["STATE_TTL_HOURS"] = "72"
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+
+@pytest.fixture
+def app():
+    from tools.state import router, _STATE_STORE, _TRANSITION_STORE, _CONVERSATION_STORE, _lock
+    with _lock:
+        _STATE_STORE.clear()
+        _TRANSITION_STORE.clear()
+        _CONVERSATION_STORE.clear()
+    test_app = FastAPI()
+    test_app.include_router(router, prefix="/mcp")
+    return test_app
+
+
+@pytest.fixture(autouse=True)
+def clear_stores():
+    from tools.state import _STATE_STORE, _TRANSITION_STORE, _CONVERSATION_STORE, _lock
+    with _lock:
+        _STATE_STORE.clear()
+        _TRANSITION_STORE.clear()
+        _CONVERSATION_STORE.clear()
+    yield
+
+
+@pytest.mark.asyncio
+async def test_get_default_state(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/state.get", json={"volunteerId": "new-vol"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["state"] == "WELCOME"
+        assert data["expired"] is False
+
+
+@pytest.mark.asyncio
+async def test_advance_state(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/state.advance", json={
+            "volunteerId": "vol-1",
+            "intent": "to_ELIGIBILITY_PART1"
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["new_state"] == "ELIGIBILITY_PART1"
+        assert data["previous_state"] == "WELCOME"
+        assert data["next_required_fields"] == ["age_ok", "has_device"]
+
+
+@pytest.mark.asyncio
+async def test_advance_invalid_transition(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # First advance to ELIGIBILITY_PART1
+        await client.post("/mcp/state.advance", json={
+            "volunteerId": "vol-1", "intent": "to_ELIGIBILITY_PART1"
+        })
+        # Try to skip ahead to SCHEDULING (invalid)
+        resp = await client.post("/mcp/state.advance", json={
+            "volunteerId": "vol-1", "intent": "to_SCHEDULING"
+        })
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_advance_idempotency(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        key = "idem-key-123"
+        resp1 = await client.post("/mcp/state.advance", json={
+            "volunteerId": "vol-1", "intent": "to_ELIGIBILITY_PART1", "idempotency_key": key
+        })
+        resp2 = await client.post("/mcp/state.advance", json={
+            "volunteerId": "vol-1", "intent": "to_ELIGIBILITY_PART1", "idempotency_key": key
+        })
+        assert resp1.json()["transitioned_at"] == resp2.json()["transitioned_at"]
+
+
+@pytest.mark.asyncio
+async def test_terminal_state_from_any(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/state.advance", json={
+            "volunteerId": "vol-1", "intent": "to_REJECTED"
+        })
+        assert resp.status_code == 200
+        assert resp.json()["new_state"] == "REJECTED"
+
+
+@pytest.mark.asyncio
+async def test_conversation_save_and_get(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Save conversation state
+        resp = await client.post("/mcp/conversation.save", json={
+            "volunteerId": "vol-1",
+            "state": {"step": "collecting_name", "facts": {"age": 25}, "messages": ["hi"]}
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["saved"] is True
+        assert data["version"] == 1
+        assert "expires_at" in data
+
+        # Get it back
+        resp = await client.post("/mcp/conversation.get", json={"volunteerId": "vol-1"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["found"] is True
+        assert data["state"]["step"] == "collecting_name"
+        assert data["state"]["facts"]["age"] == 25
+        assert data["expired"] is False
+        assert data["version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_conversation_get_not_found(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/conversation.get", json={"volunteerId": "unknown"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["found"] is False
+
+
+@pytest.mark.asyncio
+async def test_conversation_version_increments(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/mcp/conversation.save", json={
+            "volunteerId": "vol-1", "state": {"v": 1}
+        })
+        resp = await client.post("/mcp/conversation.save", json={
+            "volunteerId": "vol-1", "state": {"v": 2}
+        })
+        assert resp.json()["version"] == 2
+
+        resp = await client.post("/mcp/conversation.get", json={"volunteerId": "vol-1"})
+        assert resp.json()["state"]["v"] == 2


### PR DESCRIPTION
## Summary
- Adds file-based persistence (JSONL) to the onboarding state store — survives restarts
- Adds `conversation.save` and `conversation.get` endpoints for storing arbitrary agent state
- Implements configurable TTL expiry (default 72h) with `STATE_TTL_HOURS` env var
- Expiry is checked on read and reported in response (`expired: true/false`)
- Versioning support for conversation state (auto-incrementing version number)
- Fixes state transition validation to prevent skipping steps

Closes #5

## Test plan
- [x] `python3 -m pytest test_state.py -v` — all 8 tests pass
- [ ] Verify state persists after process restart by checking `state_store/` JSONL files
- [ ] Verify expired states are correctly flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)