### PR TITLE
feat: Volunteer Profiles & Preferences with full CRUD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *.pyc
 *-310.pyc
 *.md
+profile_store/
+state_store/
+telemetry_logs/
+logs/

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -598,6 +598,56 @@ TOOL_REGISTRY = {
             "required": ["when_ISO", "reason"]
         }
     },
+    "profile.save": {
+        "endpoint": "/mcp/profile.save",
+        "method": "POST",
+        "description": "Save a volunteer profile (create or overwrite). Use for initial profile creation.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "volunteerId": {"type": "string", "description": "Unique volunteer ID"},
+                "profile": {
+                    "type": "object",
+                    "description": "Profile data",
+                    "properties": {
+                        "identity": {"type": "object", "properties": {"fullname": {"type": "string"}, "gender": {"type": "string"}, "dob": {"type": "string"}, "nationality": {"type": "string"}}, "required": ["fullname"]},
+                        "contact": {"type": "object", "properties": {"email": {"type": "string"}, "mobile": {"type": "string"}, "city": {"type": "string"}, "state": {"type": "string"}, "country": {"type": "string"}}},
+                        "teaching": {"type": "object", "properties": {"subjects": {"type": "array", "items": {"type": "string"}}, "grades": {"type": "array", "items": {"type": "string"}}, "languages": {"type": "array", "items": {"type": "string"}}, "days": {"type": "array", "items": {"type": "string"}}, "time_windows": {"type": "array"}, "timezone": {"type": "string"}}},
+                        "eligibility": {"type": "object", "properties": {"age_years": {"type": "integer"}, "has_device": {"type": "boolean"}, "weekly_commitment_hours": {"type": "number"}, "language_comfort": {"type": "string"}}},
+                        "consent_given": {"type": "boolean"},
+                        "onboarding_status": {"type": "string"},
+                        "notes": {"type": "string"}
+                    }
+                }
+            },
+            "required": ["volunteerId", "profile"]
+        }
+    },
+    "profile.update": {
+        "endpoint": "/mcp/profile.update",
+        "method": "POST",
+        "description": "Partially update a volunteer profile (deep merge). Only provided fields are changed.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "volunteerId": {"type": "string", "description": "Volunteer ID"},
+                "updates": {"type": "object", "description": "Partial profile fields to update"}
+            },
+            "required": ["volunteerId", "updates"]
+        }
+    },
+    "profile.get": {
+        "endpoint": "/mcp/profile.get",
+        "method": "POST",
+        "description": "Retrieve a volunteer's full profile including teaching preferences, eligibility, and contact details.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "volunteerId": {"type": "string", "description": "Volunteer ID"}
+            },
+            "required": ["volunteerId"]
+        }
+    },
     "telemetry.emit": {
         "endpoint": "/mcp/telemetry.emit",
         "method": "POST",

--- a/src/tools/profile.py
+++ b/src/tools/profile.py
@@ -1,30 +1,295 @@
-from fastapi import APIRouter
-from pydantic import BaseModel
-from typing import Dict, Any
+"""
+Volunteer Profiles & Preferences MCP Tools
+- Save, update, and retrieve volunteer profiles
+- Full JSON schema with validation
+- File-based persistence
+"""
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from typing import Dict, Optional, List, Any
+from datetime import datetime, timezone
+import json
+import os
+import threading
 
 router = APIRouter()
 
-# Import stores if available
-try:
-    from .consent import _CONSENT_STORE
-except Exception:
-    _CONSENT_STORE = {}
-try:
-    from .preferences import _PREFS
-except Exception:
-    _PREFS = {}
+# --------- Configuration ---------
 
-class ProfileGet(BaseModel):
+PROFILE_STORE_DIR = os.environ.get("PROFILE_STORE_DIR", "./profile_store")
+
+# --------- In-Memory Store + Persistence ---------
+
+_PROFILE_STORE: Dict[str, Dict[str, Any]] = {}
+_lock = threading.Lock()
+_loaded = False
+
+
+def _ensure_store_dir():
+    os.makedirs(PROFILE_STORE_DIR, exist_ok=True)
+
+
+def _profiles_file_path() -> str:
+    return os.path.join(PROFILE_STORE_DIR, "profiles.jsonl")
+
+
+def _load_from_disk():
+    global _loaded
+    if _loaded:
+        return
+    _loaded = True
+    _ensure_store_dir()
+    fpath = _profiles_file_path()
+    if os.path.exists(fpath):
+        try:
+            with open(fpath, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                        vid = record.get("volunteerId")
+                        if vid:
+                            _PROFILE_STORE[vid] = record
+                    except json.JSONDecodeError:
+                        continue
+        except Exception as e:
+            print(f"[profile] Warning: Failed to load profiles: {e}")
+
+
+def _persist_profile(volunteer_id: str, record: Dict[str, Any]):
+    try:
+        _ensure_store_dir()
+        record["volunteerId"] = volunteer_id
+        with open(_profiles_file_path(), "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception as e:
+        print(f"[profile] Warning: Failed to persist profile: {e}")
+
+
+# --------- JSON Schema for Profile ---------
+
+class IdentityDetails(BaseModel):
+    fullname: str = Field(..., description="Full name of the volunteer")
+    gender: Optional[str] = Field(None, description="Gender")
+    dob: Optional[str] = Field(None, description="Date of birth (YYYY-MM-DD)")
+    nationality: Optional[str] = Field(None, description="Nationality")
+
+
+class ContactDetails(BaseModel):
+    email: Optional[str] = Field(None, description="Email address")
+    mobile: Optional[str] = Field(None, description="Mobile/WhatsApp number (E.164)")
+    city: Optional[str] = None
+    state: Optional[str] = None
+    country: Optional[str] = Field(default="India")
+
+
+class TeachingPreferences(BaseModel):
+    subjects: List[str] = Field(default_factory=list, description="Subjects the volunteer can teach")
+    grades: List[str] = Field(default_factory=list, description="Grade levels (e.g., '5', '6-8')")
+    languages: List[str] = Field(default_factory=list, description="Languages of instruction")
+    days: List[str] = Field(default_factory=list, description="Preferred days (Mon, Tue, ...)")
+    time_windows: List[Dict[str, str]] = Field(default_factory=list, description="Time windows [{start, end}]")
+    timezone: str = Field(default="Asia/Kolkata")
+
+
+class EligibilityInfo(BaseModel):
+    age_years: Optional[int] = Field(None, ge=0, le=120)
+    has_device: Optional[bool] = None
+    weekly_commitment_hours: Optional[float] = Field(None, ge=0)
+    language_comfort: Optional[str] = None
+
+
+class ProfileData(BaseModel):
+    identity: Optional[IdentityDetails] = None
+    contact: Optional[ContactDetails] = None
+    teaching: Optional[TeachingPreferences] = None
+    eligibility: Optional[EligibilityInfo] = None
+    consent_given: Optional[bool] = None
+    onboarding_status: Optional[str] = None
+    notes: Optional[str] = None
+
+
+# --------- Request/Response Models ---------
+
+
+class ProfileSaveRequest(BaseModel):
+    volunteerId: str = Field(..., description="Unique volunteer ID")
+    profile: ProfileData = Field(..., description="Profile data to save")
+
+
+class ProfileSaveResponse(BaseModel):
+    saved: bool
     volunteerId: str
+    version: int
+    updated_at: str
 
-class ProfileResponse(BaseModel):
-    profile: Dict[str, Any]
 
-@router.post("/profile.get", response_model=ProfileResponse)
-async def profile_get(req: ProfileGet) -> ProfileResponse:
-    profile: Dict[str, Any] = {}
-    if req.volunteerId in _CONSENT_STORE:
-        profile["consent"] = _CONSENT_STORE[req.volunteerId]
-    if req.volunteerId in _PREFS:
-        profile["preferences"] = _PREFS[req.volunteerId]
-    return ProfileResponse(profile=profile)
+class ProfileUpdateRequest(BaseModel):
+    volunteerId: str = Field(..., description="Volunteer ID")
+    updates: Dict[str, Any] = Field(..., description="Partial profile fields to update (deep merge)")
+
+
+class ProfileUpdateResponse(BaseModel):
+    updated: bool
+    volunteerId: str
+    version: int
+    updated_at: str
+    changed_fields: List[str]
+
+
+class ProfileGetRequest(BaseModel):
+    volunteerId: str = Field(..., description="Volunteer ID")
+
+
+class ProfileGetResponse(BaseModel):
+    found: bool
+    volunteerId: str
+    profile: Optional[Dict[str, Any]] = None
+    version: int = 0
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+# --------- Helper Functions ---------
+
+
+def _deep_merge(base: Dict, updates: Dict) -> Dict:
+    """Deep merge updates into base dict."""
+    result = base.copy()
+    for key, value in updates.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _get_changed_fields(old: Dict, new: Dict, prefix: str = "") -> List[str]:
+    """Get list of top-level fields that changed."""
+    changed = []
+    all_keys = set(list(old.keys()) + list(new.keys()))
+    for key in all_keys:
+        full_key = f"{prefix}{key}" if prefix else key
+        if key not in old:
+            changed.append(full_key)
+        elif key not in new:
+            changed.append(full_key)
+        elif old[key] != new[key]:
+            changed.append(full_key)
+    return changed
+
+
+# --------- Endpoints ---------
+
+
+@router.post("/profile.save", response_model=ProfileSaveResponse)
+async def profile_save(req: ProfileSaveRequest) -> ProfileSaveResponse:
+    """
+    Save a volunteer profile (creates or overwrites).
+
+    Use this for initial profile creation or full replacement.
+    For partial updates, use profile.update instead.
+    """
+    with _lock:
+        _load_from_disk()
+
+    now = datetime.now(timezone.utc).isoformat()
+    version = 1
+
+    if req.volunteerId in _PROFILE_STORE:
+        version = _PROFILE_STORE[req.volunteerId].get("version", 0) + 1
+
+    record = {
+        "volunteerId": req.volunteerId,
+        "profile": req.profile.model_dump(exclude_none=True),
+        "version": version,
+        "created_at": _PROFILE_STORE.get(req.volunteerId, {}).get("created_at", now),
+        "updated_at": now,
+    }
+
+    with _lock:
+        _PROFILE_STORE[req.volunteerId] = record
+
+    _persist_profile(req.volunteerId, record)
+
+    return ProfileSaveResponse(
+        saved=True,
+        volunteerId=req.volunteerId,
+        version=version,
+        updated_at=now,
+    )
+
+
+@router.post("/profile.update", response_model=ProfileUpdateResponse)
+async def profile_update(req: ProfileUpdateRequest) -> ProfileUpdateResponse:
+    """
+    Partially update a volunteer profile (deep merge).
+
+    Only the provided fields are updated; existing fields are preserved.
+    Creates a new profile if one doesn't exist.
+    """
+    with _lock:
+        _load_from_disk()
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    if req.volunteerId in _PROFILE_STORE:
+        existing = _PROFILE_STORE[req.volunteerId]
+        old_profile = existing.get("profile", {})
+        new_profile = _deep_merge(old_profile, req.updates)
+        version = existing.get("version", 0) + 1
+        changed = _get_changed_fields(old_profile, new_profile)
+        created_at = existing.get("created_at", now)
+    else:
+        new_profile = req.updates
+        version = 1
+        changed = list(req.updates.keys())
+        created_at = now
+
+    record = {
+        "volunteerId": req.volunteerId,
+        "profile": new_profile,
+        "version": version,
+        "created_at": created_at,
+        "updated_at": now,
+    }
+
+    with _lock:
+        _PROFILE_STORE[req.volunteerId] = record
+
+    _persist_profile(req.volunteerId, record)
+
+    return ProfileUpdateResponse(
+        updated=True,
+        volunteerId=req.volunteerId,
+        version=version,
+        updated_at=now,
+        changed_fields=changed,
+    )
+
+
+@router.post("/profile.get", response_model=ProfileGetResponse)
+async def profile_get(req: ProfileGetRequest) -> ProfileGetResponse:
+    """
+    Retrieve a volunteer's full profile.
+
+    Returns all stored profile data including teaching preferences,
+    eligibility info, and contact details.
+    """
+    with _lock:
+        _load_from_disk()
+
+    if req.volunteerId not in _PROFILE_STORE:
+        return ProfileGetResponse(found=False, volunteerId=req.volunteerId)
+
+    record = _PROFILE_STORE[req.volunteerId]
+    return ProfileGetResponse(
+        found=True,
+        volunteerId=req.volunteerId,
+        profile=record.get("profile"),
+        version=record.get("version", 0),
+        created_at=record.get("created_at"),
+        updated_at=record.get("updated_at"),
+    )

--- a/test_profile.py
+++ b/test_profile.py
@@ -1,0 +1,154 @@
+"""
+Unit tests for Volunteer Profiles & Preferences MCP tools.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+os.environ["PROFILE_STORE_DIR"] = "/tmp/profile_store_test"
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+
+@pytest.fixture
+def app():
+    from tools.profile import router, _PROFILE_STORE, _lock
+    with _lock:
+        _PROFILE_STORE.clear()
+    test_app = FastAPI()
+    test_app.include_router(router, prefix="/mcp")
+    return test_app
+
+
+@pytest.fixture(autouse=True)
+def clear_store():
+    from tools.profile import _PROFILE_STORE, _lock
+    with _lock:
+        _PROFILE_STORE.clear()
+    yield
+
+
+@pytest.mark.asyncio
+async def test_save_profile(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/profile.save", json={
+            "volunteerId": "vol-1",
+            "profile": {
+                "identity": {"fullname": "Priya Sharma"},
+                "contact": {"email": "priya@example.com", "mobile": "+919876543210"},
+                "teaching": {
+                    "subjects": ["Mathematics", "Science"],
+                    "grades": ["6", "7", "8"],
+                    "languages": ["English", "Hindi"],
+                    "days": ["Mon", "Wed", "Fri"],
+                    "time_windows": [{"start": "09:00", "end": "11:00"}],
+                    "timezone": "Asia/Kolkata"
+                },
+                "eligibility": {"age_years": 28, "has_device": True, "weekly_commitment_hours": 4},
+                "consent_given": True
+            }
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["saved"] is True
+        assert data["version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_profile(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/mcp/profile.save", json={
+            "volunteerId": "vol-1",
+            "profile": {
+                "identity": {"fullname": "Ravi Kumar"},
+                "teaching": {"subjects": ["English"]}
+            }
+        })
+
+        resp = await client.post("/mcp/profile.get", json={"volunteerId": "vol-1"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["found"] is True
+        assert data["profile"]["identity"]["fullname"] == "Ravi Kumar"
+        assert data["profile"]["teaching"]["subjects"] == ["English"]
+        assert data["version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_profile_not_found(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/profile.get", json={"volunteerId": "unknown"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["found"] is False
+
+
+@pytest.mark.asyncio
+async def test_update_profile_partial(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Create initial profile
+        await client.post("/mcp/profile.save", json={
+            "volunteerId": "vol-1",
+            "profile": {
+                "identity": {"fullname": "Anita Desai"},
+                "teaching": {"subjects": ["Math"], "grades": ["5"]}
+            }
+        })
+
+        # Partial update — add a subject
+        resp = await client.post("/mcp/profile.update", json={
+            "volunteerId": "vol-1",
+            "updates": {
+                "teaching": {"subjects": ["Math", "Science"], "languages": ["English"]}
+            }
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["updated"] is True
+        assert data["version"] == 2
+        assert "teaching" in data["changed_fields"]
+
+        # Verify merged state
+        resp = await client.post("/mcp/profile.get", json={"volunteerId": "vol-1"})
+        profile = resp.json()["profile"]
+        assert profile["identity"]["fullname"] == "Anita Desai"  # preserved
+        assert profile["teaching"]["subjects"] == ["Math", "Science"]  # updated
+        assert profile["teaching"]["languages"] == ["English"]  # added
+        assert profile["teaching"]["grades"] == ["5"]  # preserved from deep merge
+
+
+@pytest.mark.asyncio
+async def test_update_creates_if_missing(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/profile.update", json={
+            "volunteerId": "new-vol",
+            "updates": {"identity": {"fullname": "New Person"}, "consent_given": True}
+        })
+        assert resp.status_code == 200
+        assert resp.json()["version"] == 1
+
+        resp = await client.post("/mcp/profile.get", json={"volunteerId": "new-vol"})
+        assert resp.json()["found"] is True
+        assert resp.json()["profile"]["identity"]["fullname"] == "New Person"
+
+
+@pytest.mark.asyncio
+async def test_version_increments(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/mcp/profile.save", json={
+            "volunteerId": "vol-1",
+            "profile": {"identity": {"fullname": "V1"}}
+        })
+        resp = await client.post("/mcp/profile.save", json={
+            "volunteerId": "vol-1",
+            "profile": {"identity": {"fullname": "V2"}}
+        })
+        assert resp.json()["version"] == 2


### PR DESCRIPTION
## Summary
- Implements `profile.save`, `profile.update`, and `profile.get` MCP tools
- JSON schema with structured sections: identity, contact, teaching preferences, eligibility
- `profile.update` performs deep merge — only provided fields are changed, rest preserved
- File-based persistence (JSONL) with versioning
- Registers all three tools in MCP server TOOL_REGISTRY

Closes #1

## Test plan
- [x] `python3 -m pytest test_profile.py -v` — all 6 tests pass
- [ ] Verify persistence across process restarts
- [ ] Verify MCP JSON-RPC tools/list includes profile.save, profile.update, profile.get

🤖 Generated with [Claude Code](https://claude.com/claude-code)