### PR TITLE
feat: Add getNeedDetails and getVolunteerStatus tools

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -20,6 +20,7 @@ from tools import knowledge, llm_qa, onboarding_turns
 from tools import serve_needs, serve_fulfill
 from tools import wa_video
 from tools import serve_volunteering
+from tools import serve_status
 from mcp_tools.firebase_auth import email_exists_router, ensure_user_router
 from mcp_tools.serve_volunteer import update_status_router
 
@@ -90,6 +91,7 @@ app.include_router(serve_needs.router, prefix="/mcp")  # Serve needs list
 app.include_router(serve_fulfill.router, prefix="/mcp")  # Serve fulfillment nomination
 app.include_router(wa_video.router, prefix="/mcp")  # WhatsApp video sending
 app.include_router(serve_volunteering.router, prefix="/mcp")  # Serve volunteering tools
+app.include_router(serve_status.router, prefix="/mcp")  # Volunteer status
 app.include_router(email_exists_router, prefix="/mcp")  # Firebase auth: email exists
 app.include_router(ensure_user_router, prefix="/mcp")  # Firebase auth: ensure user
 app.include_router(update_status_router, prefix="/mcp")  # SERVE volunteer: update status

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -730,6 +730,30 @@ TOOL_REGISTRY = {
             }
         }
     },
+    "serve.needs.get": {
+        "endpoint": "/mcp/serve.needs.get",
+        "method": "POST",
+        "description": "Get detailed information about a specific Serve need by ID",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "needId": {"type": "string", "description": "UUID of the Serve need"}
+            },
+            "required": ["needId"]
+        }
+    },
+    "serve.volunteer.status": {
+        "endpoint": "/mcp/serve.volunteer.status",
+        "method": "POST",
+        "description": "Get comprehensive volunteer status: onboarding progress, nomination history, and profile completion",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "volunteerId": {"type": "string", "description": "SERVE volunteer osid"}
+            },
+            "required": ["volunteerId"]
+        }
+    },
     "serve.fulfill.nominate": {
         "endpoint": "/mcp/serve.fulfill.nominate",
         "method": "POST",

--- a/src/tools/serve_needs.py
+++ b/src/tools/serve_needs.py
@@ -325,3 +325,55 @@ async def serve_needs_list(req: ServeNeedsListRequest) -> ServeNeedsListResponse
             detail=f"Failed to parse Serve needs response: {str(e)}"
         )
 
+
+# --------- Need Details Endpoint ---------
+
+class NeedDetailsRequest(BaseModel):
+    """Request parameters for getting need details"""
+    needId: str = Field(..., description="UUID of the Serve need")
+
+class NeedDetailsResponse(BaseModel):
+    """Detailed information about a single need"""
+    found: bool
+    need: Optional[ServeNeedItem] = None
+    raw: Optional[Dict[str, Any]] = None
+    message: str = ""
+
+@router.post("/serve.needs.get", response_model=NeedDetailsResponse)
+async def serve_needs_get(req: NeedDetailsRequest) -> NeedDetailsResponse:
+    """
+    Get detailed information about a specific Serve need by ID.
+    """
+    url = f"{SERVE_API_BASE_URL}{req.needId}"
+
+    try:
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+            response = await client.get(url)
+
+            if response.status_code == 404:
+                return NeedDetailsResponse(
+                    found=False,
+                    message=f"Need not found: {req.needId}"
+                )
+
+            response.raise_for_status()
+            data = response.json()
+
+            # Map the response
+            mapped = _map_serve_response_item(data)
+            return NeedDetailsResponse(
+                found=True,
+                need=mapped,
+                raw=data,
+                message="Need found"
+            )
+
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail="Request timeout fetching need details")
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            return NeedDetailsResponse(found=False, message=f"Need not found: {req.needId}")
+        raise HTTPException(status_code=502, detail=f"Failed to fetch need: HTTP {e.response.status_code}")
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Failed to fetch need details: {str(e)}")
+

--- a/src/tools/serve_status.py
+++ b/src/tools/serve_status.py
@@ -1,0 +1,163 @@
+"""
+Serve Volunteer Status Tool
+- Get volunteer status from SERVE system
+- Returns onboarding status, nomination history, and activity summary
+"""
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from typing import Optional, List, Dict, Any
+import httpx
+
+from config import settings
+
+router = APIRouter()
+
+SERVE_BASE_URL = settings.SERVE_BASE_URL
+HTTP_TIMEOUT = settings.SERVE_TIMEOUT_SECONDS
+
+# --------- Models ---------
+
+
+class VolunteerStatusRequest(BaseModel):
+    volunteerId: str = Field(..., description="SERVE volunteer osid")
+
+
+class NominationInfo(BaseModel):
+    needId: str = ""
+    needTitle: str = ""
+    status: str = ""
+    nominatedAt: str = ""
+
+
+class VolunteerStatusResponse(BaseModel):
+    found: bool
+    volunteerId: str
+    status: str = ""
+    onboardStatus: str = ""
+    name: str = ""
+    email: str = ""
+    nominations: List[NominationInfo] = Field(default_factory=list)
+    profile_completion: str = ""
+    message: str = ""
+
+
+# --------- Helpers ---------
+
+
+def _extract_onboard_status(profile_data: Dict[str, Any]) -> str:
+    """Extract onboard status from profile response."""
+    onboard_details = profile_data.get("onboardDetails", {})
+    if isinstance(onboard_details, dict):
+        statuses = onboard_details.get("onboardStatus", [])
+        if isinstance(statuses, list) and statuses:
+            last = statuses[-1]
+            if isinstance(last, dict):
+                return f"{last.get('onboardStep', '')}:{last.get('status', '')}"
+    return ""
+
+
+def _extract_nominations(fulfillments: List[Dict[str, Any]]) -> List[NominationInfo]:
+    """Extract nomination info from fulfillment data."""
+    nominations = []
+    for f in fulfillments:
+        if not isinstance(f, dict):
+            continue
+        nominations.append(NominationInfo(
+            needId=str(f.get("needId") or f.get("need", {}).get("id", "")),
+            needTitle=f.get("need", {}).get("name", "") if isinstance(f.get("need"), dict) else "",
+            status=f.get("status", ""),
+            nominatedAt=str(f.get("createdAt") or f.get("created_at") or ""),
+        ))
+    return nominations
+
+
+# --------- Endpoint ---------
+
+
+@router.post("/serve.volunteer.status", response_model=VolunteerStatusResponse)
+async def get_volunteer_status(req: VolunteerStatusRequest) -> VolunteerStatusResponse:
+    """
+    Get comprehensive volunteer status from SERVE system.
+
+    Fetches user info, profile, and nomination history.
+    """
+    volunteer_id = req.volunteerId
+
+    try:
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+            # Fetch user basic info
+            user_url = f"{SERVE_BASE_URL}/api/v1/serve-volunteering/user/{volunteer_id}"
+            user_resp = await client.get(user_url)
+
+            if user_resp.status_code == 404:
+                return VolunteerStatusResponse(
+                    found=False,
+                    volunteerId=volunteer_id,
+                    message="Volunteer not found"
+                )
+
+            if user_resp.status_code != 200:
+                return VolunteerStatusResponse(
+                    found=False,
+                    volunteerId=volunteer_id,
+                    message=f"Failed to fetch volunteer: HTTP {user_resp.status_code}"
+                )
+
+            user_data = user_resp.json()
+
+            # Extract basic info
+            identity = user_data.get("identityDetails", {})
+            contact = user_data.get("contactDetails", {})
+            name = identity.get("fullname") or identity.get("name") or ""
+            email = contact.get("email") or ""
+            status = user_data.get("status") or ""
+
+            # Try to fetch profile for onboard status
+            onboard_status = ""
+            profile_completion = ""
+            try:
+                profile_url = f"{SERVE_BASE_URL}/api/v1/serve-volunteering/user/user-profile/{volunteer_id}"
+                profile_resp = await client.get(profile_url)
+                if profile_resp.status_code == 200:
+                    profile_data = profile_resp.json()
+                    onboard_status = _extract_onboard_status(profile_data)
+                    profile_completion = str(
+                        profile_data.get("onboardDetails", {}).get("profileCompletion", "")
+                    )
+            except Exception:
+                pass
+
+            # Try to fetch nominations/fulfillments
+            nominations: List[NominationInfo] = []
+            try:
+                fulfill_url = f"{SERVE_BASE_URL}/api/v1/serve-fulfill/nomination/volunteer/{volunteer_id}"
+                fulfill_resp = await client.get(fulfill_url)
+                if fulfill_resp.status_code == 200:
+                    fulfill_data = fulfill_resp.json()
+                    if isinstance(fulfill_data, list):
+                        nominations = _extract_nominations(fulfill_data)
+                    elif isinstance(fulfill_data, dict):
+                        items = fulfill_data.get("content", fulfill_data.get("items", []))
+                        if isinstance(items, list):
+                            nominations = _extract_nominations(items)
+            except Exception:
+                pass
+
+            return VolunteerStatusResponse(
+                found=True,
+                volunteerId=volunteer_id,
+                status=status,
+                onboardStatus=onboard_status,
+                name=name,
+                email=email,
+                nominations=nominations,
+                profile_completion=profile_completion,
+                message="Volunteer found",
+            )
+
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail="Request timeout fetching volunteer status")
+    except httpx.ConnectError as e:
+        raise HTTPException(status_code=502, detail=f"Connection error: {str(e)}")
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Failed to fetch volunteer status: {str(e)}")

--- a/test_serve_needs_status.py
+++ b/test_serve_needs_status.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for Serve Needs (getNeedDetails) and Volunteer Status tools.
+Tests response models and helpers without calling external APIs.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+import pytest
+from tools.serve_needs import _map_serve_response_item, _parse_iso_date, _parse_time_to_hhmm
+from tools.serve_status import _extract_onboard_status, _extract_nominations
+
+
+class TestNeedsHelpers:
+    def test_parse_iso_date(self):
+        assert _parse_iso_date("2026-06-10T00:00:00Z") == "2026-06-10"
+        assert _parse_iso_date("2026-06-10") == "2026-06-10"
+        assert _parse_iso_date("") == ""
+        assert _parse_iso_date(None) == ""
+
+    def test_parse_time_to_hhmm(self):
+        assert _parse_time_to_hhmm("2026-06-10T09:30:00+05:30") == "09:30"
+        assert _parse_time_to_hhmm("14:00:00") == "14:00"
+        assert _parse_time_to_hhmm("") == ""
+
+    def test_map_serve_response_item(self):
+        item = {
+            "id": "need-uuid-123",
+            "need": {"name": "Math Teaching", "needPurpose": "Education"},
+            "entity": {"name": "ABC School", "district": "Chennai", "state": "Tamil Nadu"},
+            "occurrence": {"startDate": "2026-06-10T00:00:00Z", "endDate": "2026-12-31T00:00:00Z"},
+            "status": "Approved",
+            "timeSlots": [
+                {"day": "Monday", "startTime": "2026-06-10T09:00:00+05:30", "endTime": "2026-06-10T10:00:00+05:30"},
+                {"day": "Wednesday", "startTime": "2026-06-10T09:00:00+05:30", "endTime": "2026-06-10T10:00:00+05:30"}
+            ]
+        }
+        result = _map_serve_response_item(item)
+        assert result.needId == "need-uuid-123"
+        assert result.title == "Math Teaching"
+        assert result.schoolName == "ABC School"
+        assert result.district == "Chennai"
+        assert "MONDAY" in result.days
+        assert "WEDNESDAY" in result.days
+        assert len(result.timeSlots) == 2
+        assert result.timeSlots[0].startTime == "09:00"
+
+
+class TestStatusHelpers:
+    def test_extract_onboard_status(self):
+        profile_data = {
+            "onboardDetails": {
+                "onboardStatus": [
+                    {"onboardStep": "Discussion", "status": "completed"},
+                    {"onboardStep": "Training", "status": "in-progress"}
+                ],
+                "profileCompletion": "75"
+            }
+        }
+        assert _extract_onboard_status(profile_data) == "Training:in-progress"
+
+    def test_extract_onboard_status_empty(self):
+        assert _extract_onboard_status({}) == ""
+        assert _extract_onboard_status({"onboardDetails": {}}) == ""
+
+    def test_extract_nominations(self):
+        fulfillments = [
+            {
+                "needId": "need-1",
+                "need": {"id": "need-1", "name": "Math Class"},
+                "status": "Nominated",
+                "createdAt": "2026-06-01T10:00:00Z"
+            },
+            {
+                "needId": "need-2",
+                "need": {"id": "need-2", "name": "Science Class"},
+                "status": "Confirmed",
+                "createdAt": "2026-06-05T10:00:00Z"
+            }
+        ]
+        result = _extract_nominations(fulfillments)
+        assert len(result) == 2
+        assert result[0].needId == "need-1"
+        assert result[0].needTitle == "Math Class"
+        assert result[1].status == "Confirmed"
+
+    def test_extract_nominations_empty(self):
+        assert _extract_nominations([]) == []
+        assert _extract_nominations([None, "invalid"]) == []


### PR DESCRIPTION
## Summary
- Adds `serve.needs.get` endpoint to fetch detailed info about a specific need by ID
- Adds `serve.volunteer.status` endpoint that fetches comprehensive volunteer status: basic info, onboard status, profile completion, and nomination history
- Registers both tools in the MCP TOOL_REGISTRY
- Error handling for 404s, timeouts, and connection failures

Closes #2

## Test plan
- [x] `python3 -m pytest test_serve_needs_status.py -v` — all 7 tests pass
- [ ] Integration: call `serve.needs.get` with a real need ID from the Serve API
- [ ] Integration: call `serve.volunteer.status` with a known volunteer osid

🤖 Generated with [Claude Code](https://claude.com/claude-code)