### PR TITLE
feat: Personalised Welcome/Orientation Video Generation

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -20,6 +20,7 @@ from tools import knowledge, llm_qa, onboarding_turns
 from tools import serve_needs, serve_fulfill
 from tools import wa_video
 from tools import serve_volunteering
+from tools import video_personalise
 from mcp_tools.firebase_auth import email_exists_router, ensure_user_router
 from mcp_tools.serve_volunteer import update_status_router
 
@@ -90,6 +91,7 @@ app.include_router(serve_needs.router, prefix="/mcp")  # Serve needs list
 app.include_router(serve_fulfill.router, prefix="/mcp")  # Serve fulfillment nomination
 app.include_router(wa_video.router, prefix="/mcp")  # WhatsApp video sending
 app.include_router(serve_volunteering.router, prefix="/mcp")  # Serve volunteering tools
+app.include_router(video_personalise.router, prefix="/mcp")  # Personalised video generation
 app.include_router(email_exists_router, prefix="/mcp")  # Firebase auth: email exists
 app.include_router(ensure_user_router, prefix="/mcp")  # Firebase auth: ensure user
 app.include_router(update_status_router, prefix="/mcp")  # SERVE volunteer: update status

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -784,6 +784,36 @@ TOOL_REGISTRY = {
             "required": ["to_phone"]
         }
     },
+    "video.generate_personalised": {
+        "endpoint": "/mcp/video.generate_personalised",
+        "method": "POST",
+        "description": "Generate a personalised video context (caption + video path) for a volunteer. Returns ready-to-send video info.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Volunteer's name for personalisation"},
+                "context": {"type": "string", "enum": ["welcome", "orientation", "thankyou"], "description": "Video context type"},
+                "locale": {"type": "string", "default": "en-IN", "description": "Locale for caption language"},
+                "custom_message": {"type": "string", "description": "Optional custom message to append to caption"}
+            },
+            "required": ["name", "context"]
+        }
+    },
+    "video.send_personalised": {
+        "endpoint": "/mcp/video.send_personalised",
+        "method": "POST",
+        "description": "Generate and send a personalised video via WhatsApp (template video + personalised caption with volunteer's name)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "to_phone": {"type": "string", "description": "Recipient phone number (E.164 format)"},
+                "name": {"type": "string", "description": "Volunteer's name for personalisation"},
+                "context": {"type": "string", "enum": ["welcome", "orientation", "thankyou"], "default": "welcome", "description": "Video context type"},
+                "custom_message": {"type": "string", "description": "Optional custom caption text"}
+            },
+            "required": ["to_phone", "name"]
+        }
+    },
     "serve.volunteer.email_exists": {
         "endpoint": "/mcp/serve.volunteer.email_exists",
         "method": "POST",

--- a/src/tools/video_personalise.py
+++ b/src/tools/video_personalise.py
@@ -1,0 +1,199 @@
+"""
+Video MCP: Personalised Welcome/Orientation Video
+- Generate personalised video context for volunteers
+- Send template video with personalised caption via WhatsApp
+- Extensible architecture for future video overlay/TTS generation
+
+Current implementation: Template video + personalised caption
+Future extension points: ffmpeg overlay, TTS audio, external video API
+"""
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+from typing import Optional, Literal
+from datetime import datetime, timezone
+import os
+import hashlib
+
+from config import settings
+
+router = APIRouter()
+
+# --------- Configuration ---------
+
+GENERATED_VIDEO_DIR = os.environ.get("GENERATED_VIDEO_DIR", "./generated_videos")
+
+# --------- Video Templates ---------
+
+VIDEO_TEMPLATES = {
+    "welcome": {
+        "path_setting": "SERVE_WELCOME_VIDEO_PATH",
+        "default_caption": "Welcome to SERVE, {name}! We're excited to have you join our community of volunteers making a difference in education.",
+    },
+    "orientation": {
+        "path_setting": "SERVE_CLASS_VIDEO_PATH",
+        "default_caption": "Hi {name}! Here's a quick look at how orientation sessions work at SERVE. Watch this short video to know what to expect.",
+    },
+    "thankyou": {
+        "path_setting": "SERVE_THANKYOU_VIDEO_PATH",
+        "default_caption": "Thank you, {name}! Your commitment to volunteering is truly appreciated. Together we're making education accessible for all.",
+    },
+}
+
+# --------- Models ---------
+
+
+class GenerateVideoRequest(BaseModel):
+    name: str = Field(..., description="Volunteer's name for personalisation")
+    context: Literal["welcome", "orientation", "thankyou"] = Field(
+        ..., description="Video context: 'welcome', 'orientation', or 'thankyou'"
+    )
+    locale: str = Field(default="en-IN", description="Locale for caption language")
+    custom_message: Optional[str] = Field(
+        None, description="Optional custom message to append to caption"
+    )
+
+
+class GenerateVideoResponse(BaseModel):
+    ok: bool
+    videoType: str
+    videoPath: str = ""
+    caption: str = ""
+    personalisedFor: str = ""
+    videoUrl: Optional[str] = None
+    message: str = ""
+
+
+class SendPersonalisedVideoRequest(BaseModel):
+    to_phone: str = Field(..., description="Recipient phone number (E.164 format)")
+    name: str = Field(..., description="Volunteer's name for personalisation")
+    context: Literal["welcome", "orientation", "thankyou"] = Field(
+        default="welcome", description="Video context"
+    )
+    custom_message: Optional[str] = Field(None, description="Optional custom caption text")
+
+
+class SendPersonalisedVideoResponse(BaseModel):
+    ok: bool
+    media_id: Optional[str] = None
+    wa_message_id: Optional[str] = None
+    caption: str = ""
+    error: Optional[str] = None
+
+
+# --------- Helpers ---------
+
+
+def _generate_caption(name: str, context: str, custom_message: Optional[str] = None, locale: str = "en-IN") -> str:
+    """Generate a personalised caption for the video."""
+    template_info = VIDEO_TEMPLATES.get(context, VIDEO_TEMPLATES["welcome"])
+    caption = template_info["default_caption"].format(name=name)
+
+    if custom_message:
+        caption = f"{caption}\n\n{custom_message}"
+
+    return caption
+
+
+def _get_video_path(context: str) -> Optional[str]:
+    """Get the video file path for a given context."""
+    template_info = VIDEO_TEMPLATES.get(context)
+    if not template_info:
+        return None
+
+    setting_name = template_info["path_setting"]
+    path = getattr(settings, setting_name, "")
+    if not path:
+        return None
+
+    resolved = os.path.abspath(path)
+    if os.path.exists(resolved):
+        return resolved
+    return None
+
+
+# --------- Endpoints ---------
+
+
+@router.post("/video.generate_personalised", response_model=GenerateVideoResponse)
+async def generate_personalised_video(req: GenerateVideoRequest) -> GenerateVideoResponse:
+    """
+    Generate a personalised video context for a volunteer.
+
+    Currently returns the template video path with a personalised caption.
+    The agent can then use this to send via WhatsApp or other channels.
+
+    Extension point: When video generation infrastructure is available (ffmpeg,
+    TTS API, or external video service), this endpoint will generate actual
+    personalised video files with name overlay and/or TTS narration.
+    """
+    if req.context not in VIDEO_TEMPLATES:
+        return GenerateVideoResponse(
+            ok=False,
+            videoType=req.context,
+            message=f"Unknown video context: {req.context}. Valid: {list(VIDEO_TEMPLATES.keys())}"
+        )
+
+    video_path = _get_video_path(req.context)
+    caption = _generate_caption(req.name, req.context, req.custom_message, req.locale)
+
+    if not video_path:
+        return GenerateVideoResponse(
+            ok=False,
+            videoType=req.context,
+            caption=caption,
+            personalisedFor=req.name,
+            message=f"Video file not found for context '{req.context}'. Caption was generated successfully."
+        )
+
+    return GenerateVideoResponse(
+        ok=True,
+        videoType=req.context,
+        videoPath=video_path,
+        caption=caption,
+        personalisedFor=req.name,
+        message="Personalised video ready to send"
+    )
+
+
+@router.post("/video.send_personalised", response_model=SendPersonalisedVideoResponse)
+async def send_personalised_video(req: SendPersonalisedVideoRequest) -> SendPersonalisedVideoResponse:
+    """
+    Generate and send a personalised video via WhatsApp in one step.
+
+    Combines video generation (personalised caption) with WhatsApp delivery.
+    Uses the existing wa_video infrastructure for upload and sending.
+    """
+    from tools.wa_video import _send_video_internal
+
+    if not settings.WHATSAPP_ACCESS_TOKEN or not settings.WHATSAPP_PHONE_NUMBER_ID:
+        return SendPersonalisedVideoResponse(
+            ok=False,
+            error="WhatsApp API not configured (missing ACCESS_TOKEN or PHONE_NUMBER_ID)"
+        )
+
+    caption = _generate_caption(req.name, req.context, req.custom_message)
+
+    # Map context to settings path
+    path_map = {
+        "welcome": settings.SERVE_WELCOME_VIDEO_PATH,
+        "orientation": settings.SERVE_CLASS_VIDEO_PATH,
+        "thankyou": settings.SERVE_THANKYOU_VIDEO_PATH,
+    }
+    config_name_map = {
+        "welcome": "SERVE_WELCOME_VIDEO_PATH",
+        "orientation": "SERVE_CLASS_VIDEO_PATH",
+        "thankyou": "SERVE_THANKYOU_VIDEO_PATH",
+    }
+
+    video_path = path_map.get(req.context, settings.SERVE_WELCOME_VIDEO_PATH)
+    config_name = config_name_map.get(req.context, "SERVE_WELCOME_VIDEO_PATH")
+
+    result = await _send_video_internal(video_path, config_name, req.to_phone, caption)
+
+    return SendPersonalisedVideoResponse(
+        ok=result.ok,
+        media_id=result.media_id,
+        wa_message_id=result.wa_message_id,
+        caption=caption,
+        error=result.error,
+    )

--- a/test_video_personalise.py
+++ b/test_video_personalise.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for Personalised Video MCP tool.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+
+@pytest.fixture
+def app():
+    from tools.video_personalise import router
+    test_app = FastAPI()
+    test_app.include_router(router, prefix="/mcp")
+    return test_app
+
+
+@pytest.mark.asyncio
+async def test_generate_welcome_video(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/video.generate_personalised", json={
+            "name": "Priya",
+            "context": "welcome"
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "Priya" in data["caption"]
+        assert data["videoType"] == "welcome"
+        assert data["personalisedFor"] == "Priya"
+
+
+@pytest.mark.asyncio
+async def test_generate_orientation_video(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/video.generate_personalised", json={
+            "name": "Ravi Kumar",
+            "context": "orientation"
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "Ravi Kumar" in data["caption"]
+        assert data["videoType"] == "orientation"
+
+
+@pytest.mark.asyncio
+async def test_generate_thankyou_video(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/video.generate_personalised", json={
+            "name": "Anita",
+            "context": "thankyou"
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "Anita" in data["caption"]
+        assert "Thank you" in data["caption"]
+
+
+@pytest.mark.asyncio
+async def test_generate_with_custom_message(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/video.generate_personalised", json={
+            "name": "Priya",
+            "context": "welcome",
+            "custom_message": "Your orientation is on Monday at 10 AM."
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "Priya" in data["caption"]
+        assert "Monday at 10 AM" in data["caption"]
+
+
+@pytest.mark.asyncio
+async def test_generate_invalid_context(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/video.generate_personalised", json={
+            "name": "Priya",
+            "context": "invalid_context"
+        })
+        assert resp.status_code == 422  # Pydantic validation error (enum)
+
+
+@pytest.mark.asyncio
+async def test_send_personalised_no_whatsapp_config(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/video.send_personalised", json={
+            "to_phone": "+919876543210",
+            "name": "Priya",
+            "context": "welcome"
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is False
+        assert "not configured" in data["error"]


### PR DESCRIPTION
## Summary
- Adds `video.generate_personalised` MCP tool that generates personalised video context (caption with volunteer's name + video path)
- Adds `video.send_personalised` tool that generates and sends personalised video via WhatsApp in one step
- Supports three contexts: welcome, orientation, thankyou — each with name-personalised caption templates
- Supports custom messages appended to captions
- Designed for future extension: when ffmpeg/TTS infrastructure is available, the same interface will generate actual personalised video files with name overlay

Closes #3

## Test plan
- [x] `python3 -m pytest test_video_personalise.py -v` — all 6 tests pass
- [ ] Integration: send personalised welcome video to a test WhatsApp number
- [ ] Verify captions render correctly with various name lengths

🤖 Generated with [Claude Code](https://claude.com/claude-code)